### PR TITLE
:sparkles: feat: 판매자 CUD 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.session:spring-session-core'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     // Jackson -> JSON API
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 

--- a/src/main/java/com/springboot/mealkart/config/RedisConfig.java
+++ b/src/main/java/com/springboot/mealkart/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.springboot.mealkart.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private Integer redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(
+                new RedisStandaloneConfiguration(redisHost,redisPort)
+        );
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/springboot/mealkart/config/SecurityConfig.java
+++ b/src/main/java/com/springboot/mealkart/config/SecurityConfig.java
@@ -1,0 +1,125 @@
+package com.springboot.mealkart.config;
+
+
+import com.springboot.mealkart.filter.JwtFilter;
+import com.springboot.mealkart.jwt.JwtUtil;
+import com.springboot.mealkart.oauth2.CustomOAuth2UserService;
+import com.springboot.mealkart.oauth2.OAuth2LoginFailureHandler;
+import com.springboot.mealkart.oauth2.OAuth2LoginSuccessHandler;
+import com.springboot.mealkart.repository.UserRepository;
+import com.springboot.mealkart.service.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final RedisService redisService;
+    private final JwtUtil jwtUtil;
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        //configuration.setAllowedOrigins(Constant.ALLOWED_DOMAINS);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedHeaders(Collections.singletonList("*"));
+
+        configuration.setMaxAge(3600L);
+        configuration.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    /**
+     * 필터를 무시하는 메소드
+     * @return 필터 무시 메소드 uri
+     */
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring()
+                .requestMatchers(HttpMethod.GET, "/api/product/**")
+                .requestMatchers("/swagger-ui.html")
+                .requestMatchers("/api-docs")
+                .requestMatchers("/api/user/check/email/**")
+//                .requestMatchers("/oauth2/authorization/**")
+                .requestMatchers("/swagger-ui/**");
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, UserRepository userRepository) throws Exception {
+        http
+                // CSRF 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                //.userDetailsService(loginService)
+                // 폼 로그인과 HTTP Basic 인증 비활성화
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+
+                // 세션을 사용하지 않는 Stateless 설정
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler(oAuth2LoginFailureHandler)
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                )
+
+
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        //.requestMatchers(Constant.NO_SECURITY_URLS.toArray(String[] :: new)).permitAll()
+                        .anyRequest().authenticated()
+                )
+
+
+
+                // CORS 설정
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+                // JWT 필터 추가
+                .addFilterAfter(new JwtFilter(redisService, userRepository, jwtUtil), OAuth2LoginAuthenticationFilter.class)
+                .addFilterBefore(new JwtFilter(redisService, userRepository ,jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/springboot/mealkart/domain/Seller.java
+++ b/src/main/java/com/springboot/mealkart/domain/Seller.java
@@ -78,5 +78,20 @@ public class Seller extends BaseDomain {
         this.password = password;
         this.telNumber = telNumber;
         this.email = email;
+        // 2025.04.06 added by hwanhee. 디폴트값 Y
+        this.useYn = "Y";
+    }
+
+    public Boolean deactivate() {
+        this.useYn = "N";
+        return true;
+    }
+
+    public void updateBrandNameSeller(String brandName) {
+        this.brandName = brandName;
+    }
+
+    public void updatePasswordSeller(String password) {
+        this.password = password;
     }
 }

--- a/src/main/java/com/springboot/mealkart/domain/User.java
+++ b/src/main/java/com/springboot/mealkart/domain/User.java
@@ -7,10 +7,7 @@ import com.springboot.mealkart.enumerate.SocialType;
 import com.springboot.mealkart.enumerate.UserRole;
 import com.springboot.mealkart.common.util.UtilMethod;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.springframework.util.StringUtils;
 
 @Entity
@@ -38,6 +35,10 @@ public class User extends BaseDomain {
     @Column(name = "NAME")
     private String name;
 
+    // 2025.04.24 added by hwanhee. 일반 전화 null이 가능하지만 있어야함.
+    @Column(name = "GENARAL_NUM")
+    private String genaralNum;
+
     @Column(name = "PHONE_NUMBER")
     //@Convert(converter = JpaCryptoConverter.class)
     private String phoneNumber;
@@ -55,6 +56,7 @@ public class User extends BaseDomain {
     //@Convert(converter = JpaCryptoConverter.class)
     private String password;
 
+    @Setter
     @Column(name = "REFRESH_TOKEN")
     private String refreshToken;
 
@@ -86,8 +88,10 @@ public class User extends BaseDomain {
                  String zipcode,
                  String streetAddress,
                  String detailAddress,
+                 String genaralNum,
                  String phoneNumber,
                  String email,
+                 String userId,
                  String password,
                  String refreshToken,
                  String acntLockYn,
@@ -107,5 +111,8 @@ public class User extends BaseDomain {
         this.pswdErrNmtm = pswdErrNmtm;
         this.socialType = socialType;
         this.userRole = userRole;
+        this.userId = userId;
+        this.genaralNum = genaralNum;
+
     }
 }

--- a/src/main/java/com/springboot/mealkart/dto/SellerCreateDto.java
+++ b/src/main/java/com/springboot/mealkart/dto/SellerCreateDto.java
@@ -1,0 +1,29 @@
+package com.springboot.mealkart.dto;
+
+import com.springboot.mealkart.domain.Seller;
+import lombok.Getter;
+
+@Getter
+public record SellerCreateDto (
+        String sellerNumber,
+        String brandName,
+        Integer deliveryFee,
+        String sellerName,
+        String telNumber,
+        String email,
+        String password,
+        String sellerId
+) {
+    public Seller toEntity () {
+        return Seller.builder()
+                .deliveryFee(this.deliveryFee)
+                .brandName(this.brandName)
+                .sellerNumber(this.sellerNumber)
+                .sellerName(this.sellerName)
+                .sellerId(this.sellerId)
+                .password(this.password)
+                .telNumber(this.telNumber)
+                .email(this.email)
+                .build();
+    }
+}

--- a/src/main/java/com/springboot/mealkart/dto/SellerLoginDto.java
+++ b/src/main/java/com/springboot/mealkart/dto/SellerLoginDto.java
@@ -1,0 +1,10 @@
+package com.springboot.mealkart.dto;
+
+import lombok.Getter;
+
+@Getter
+public record SellerLoginDto(
+        String sellerId,
+        String password
+) {
+}

--- a/src/main/java/com/springboot/mealkart/dto/SellerUpdateDto.java
+++ b/src/main/java/com/springboot/mealkart/dto/SellerUpdateDto.java
@@ -1,0 +1,17 @@
+package com.springboot.mealkart.dto;
+
+import com.springboot.mealkart.domain.Seller;
+import lombok.Getter;
+
+@Getter
+public record SellerUpdateDto(
+        String password,
+        String brandName
+) {
+    public Seller toEntity() {
+        return Seller.builder()
+                .password(password)
+                .brandName(brandName)
+                .build();
+    }
+}

--- a/src/main/java/com/springboot/mealkart/dto/UserLoginDto.java
+++ b/src/main/java/com/springboot/mealkart/dto/UserLoginDto.java
@@ -1,0 +1,10 @@
+package com.springboot.mealkart.dto;
+
+import lombok.Getter;
+
+@Getter
+public record UserLoginDto(
+        String id,
+        String password
+) {
+}

--- a/src/main/java/com/springboot/mealkart/dto/UserRegDto.java
+++ b/src/main/java/com/springboot/mealkart/dto/UserRegDto.java
@@ -1,0 +1,30 @@
+package com.springboot.mealkart.dto;
+
+import com.springboot.mealkart.domain.User;
+
+public record UserRegDto(
+        String userId,
+        String password,
+        String name,
+        String streetAddress,
+        String detailAddress,
+        String zipcode,
+        String generalNum,
+        String phoneNumber,
+        String email
+) {
+
+    public User toEntity() {
+        return User.builder()
+                .userId(userId)
+                .password(password)
+                .name(name)
+                .streetAddress(streetAddress)
+                .detailAddress(detailAddress)
+                .zipcode(zipcode)
+                .genaralNum(generalNum)
+                .phoneNumber(phoneNumber)
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/com/springboot/mealkart/filter/JwtFilter.java
+++ b/src/main/java/com/springboot/mealkart/filter/JwtFilter.java
@@ -1,0 +1,162 @@
+package com.springboot.mealkart.filter;
+
+import com.springboot.mealkart.domain.User;
+import com.springboot.mealkart.enumerate.SocialType;
+import com.springboot.mealkart.enumerate.UserRole;
+import com.springboot.mealkart.exception.CommonException;
+import com.springboot.mealkart.exception.ErrorCode;
+import com.springboot.mealkart.jwt.JwtUtil;
+import com.springboot.mealkart.oauth2.CustomOAuth2User;
+import com.springboot.mealkart.repository.UserRepository;
+import com.springboot.mealkart.service.RedisService;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final RedisService redisService;
+    private final UserRepository userRepository;
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        logger.info(request.getRequestURI());
+        logger.info(request.getHeader("Authorization"));
+
+/*        if (Constant.NO_FILTER_URLS.stream().anyMatch(request.getRequestURI()::startsWith)) {
+            filterChain.doFilter(request, response);
+            return;
+        }*/
+
+        logger.info("***************************");
+        // 토큰
+        String token = resolveToken(request);
+
+        logger.info("----------------" + request.getHeader("Authorization"));
+
+        try {
+            //토큰에서 pid, role 획득
+            String userId = jwtUtil.getUserId(token);
+            String userRole = jwtUtil.getUserRole(token);
+            String socialType = jwtUtil.getSocialType(token);
+
+            if(socialType.isEmpty()) {
+//            log.info("provider type is empty");
+                Authentication authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                Collections.singletonList(new SimpleGrantedAuthority(userRole)));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            // 소셜 로그인 회원
+            else {
+                // user를 생성하여 값 set
+                User user = User.builder()
+                        .userId(userId)
+                        .socialType(SocialType.valueOf(socialType))
+                        .userRole(UserRole.USER_CUSTOMER) // 소셜 로그인을 사용하는건 구매자 밖에 없음.
+                        .build();
+
+                // UserDetails에 회원 정보 객체 담기
+                CustomOAuth2User customOAuth2User = new CustomOAuth2User(user);
+
+                // 스프링 시큐리티 인증 토큰 생성
+                Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, "", customOAuth2User.getAuthorities());
+                logger.info("******************************");
+                // 세션에 사용자 등록
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+
+            filterChain.doFilter(request,response);
+        } catch (JwtException e) {
+
+            String userId = jwtUtil.getUserId(token);
+
+            User user = userRepository.findByUserId(userId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
+
+            String providerType = user.getSocialType().name();
+            String role = user.getUserRole().name();
+
+            System.out.println("token expired.. regenerating...");
+            try{
+                redisService.findByKey(userId);
+                Cookie cookie = new Cookie("Authorization",jwtUtil.createJwt(
+                        userId,
+                        providerType,
+                        role,
+                        60 * 60 *60L
+                ));
+                cookie.setMaxAge(60*60*60);
+
+                cookie.setSecure(true);
+                cookie.setPath("/");
+                cookie.setHttpOnly(false);
+                response.addCookie(cookie);
+
+                filterChain.doFilter(request,response);
+                return;
+            } catch(Exception ec2){
+                throw new CommonException(ErrorCode.ACCESS_DENIED_ERROR);
+            }
+        }
+//
+//        // id, pw 로그인 회원
+//        if(providerType.isEmpty()) {
+////            log.info("provider type is empty");
+//            Authentication authentication =
+//                    new UsernamePasswordAuthenticationToken(
+//                            pid,
+//                            null,
+//                            Collections.singletonList(new SimpleGrantedAuthority(role)));
+//
+//            SecurityContextHolder.getContext().setAuthentication(authentication);
+//        }
+//        // 소셜 로그인 회원
+//        else {
+//            // user를 생성하여 값 set
+//            User user = User.builder()
+//                    .pid(pid)
+//                    .providerType(ProviderType.toEntity(providerType))
+//                    .role(UserRole.toEntity(role))
+//                    .build();
+//
+//            // UserDetails에 회원 정보 객체 담기
+//            CustomOAuth2User customOAuth2User = new CustomOAuth2User(user);
+//
+//            // 스프링 시큐리티 인증 토큰 생성
+//            Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, "", customOAuth2User.getAuthorities());
+//
+//            // 세션에 사용자 등록
+//            SecurityContextHolder.getContext().setAuthentication(authToken);
+//        }
+
+//        filterChain.doFilter(request,response);
+
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String BearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(BearerToken) && BearerToken.startsWith("Bearer")) {
+            BearerToken  = BearerToken.replace("Bearer ", "");
+            return BearerToken;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/springboot/mealkart/jwt/JwtUtil.java
+++ b/src/main/java/com/springboot/mealkart/jwt/JwtUtil.java
@@ -1,0 +1,84 @@
+package com.springboot.mealkart.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private Key key;
+
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+        byte[] byteSecretKey = Decoders.BASE64.decode(secret);
+        key = Keys.hmacShaKeyFor(byteSecretKey);
+    }
+
+    // 만료된 JWT 토큰에서 서명 검증 없이 Claims를 추출하는 방법
+    public Claims parseClaimsWithoutSignatureValidation(String token) {
+        try {
+            // 서명 검증 없이 새로운 JwtParser를 생성하여 Claims 파싱
+            JwtParser jwtParser = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build();
+            return jwtParser.parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰에서 Claims 추출
+            return e.getClaims();  // 만료된 토큰의 경우에도 Claims 반환
+        } catch (JwtException e) {
+            // JWT 파싱 오류 처리
+            throw new IllegalArgumentException("Invalid token", e);
+        }
+    }
+
+    // pid, ProviderType, role 등의 정보 추출
+    public String getUserId(String token) {
+        Claims claims = parseClaimsWithoutSignatureValidation(token);
+        return claims.get("userId", String.class);
+    }
+
+    public String getSocialType(String token) {
+        Claims claims = parseClaimsWithoutSignatureValidation(token);
+        return claims.get("socialType", String.class);
+    }
+
+    public String getUserRole(String token) {
+        Claims claims = parseClaimsWithoutSignatureValidation(token);
+        return claims.get("userRole", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String userId, String socialType, String userRole, Long expiredMs) {
+        Claims claims = Jwts.claims();
+
+        claims.put("userId", userId);
+        claims.put("socialType", socialType);
+        claims.put("userRole", userRole);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken() {
+        return Jwts.builder()
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000*60*60*24*30L))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+}

--- a/src/main/java/com/springboot/mealkart/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/springboot/mealkart/oauth2/CustomOAuth2User.java
@@ -1,0 +1,45 @@
+package com.springboot.mealkart.oauth2;
+
+import com.springboot.mealkart.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final User user;
+
+    public CustomOAuth2User(User user){
+        this.user = user;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Map.of("userId", user.getUserId(), "name", user.getName(), "email", user.getEmail());
+    }
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add((GrantedAuthority) () -> user.getUserRole().name());
+
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return user.getName();
+    }
+
+    public String getUserId() {
+        return user.getUserId();
+    }
+
+    public String getSocialType() { return user.getSocialType().name();}
+
+    public String getEmail() {return user.getEmail();}
+}

--- a/src/main/java/com/springboot/mealkart/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/springboot/mealkart/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,73 @@
+package com.springboot.mealkart.oauth2;
+
+import com.springboot.mealkart.domain.User;
+import com.springboot.mealkart.enumerate.SocialType;
+import com.springboot.mealkart.enumerate.UserRole;
+import com.springboot.mealkart.exception.CommonException;
+import com.springboot.mealkart.exception.ErrorCode;
+import com.springboot.mealkart.jwt.JwtUtil;
+import com.springboot.mealkart.repository.UserRepository;
+import com.springboot.mealkart.service.RedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final RedisService redisService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        try {
+            log.info("******************1");
+
+            OAuth2User oAuth2User = super.loadUser(userRequest);
+
+
+            String registrationId = userRequest.getClientRegistration().getRegistrationId();
+            final OAuth2Response oAuth2Response;
+            final SocialType socialType;
+
+            if (registrationId.equals("google")){
+                oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+                socialType = SocialType.TYPE_GOOGLE;
+            }else if(registrationId.equals("kakao")) {
+                oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
+                socialType = SocialType.TYPE_KAKAO;
+            }
+            else {
+                throw new CommonException(ErrorCode.AUTH_SERVER_USER_INFO_ERROR);
+            }
+            String userId = oAuth2Response.getUserId();
+
+            return new CustomOAuth2User(
+                    userRepository.findByEmail(oAuth2Response.getEmail())
+                    .orElseGet(
+                            () -> {
+                                User user = User.builder()
+                                        .userId(userId)
+                                        .email(oAuth2Response.getEmail())
+                                        .name(oAuth2Response.getName())
+                                        .userRole(UserRole.USER_CUSTOMER)
+                                        .socialType(socialType)
+                                        .password("NULL")
+                                        .build();
+                                userRepository.save(user);
+                                return user;
+                            }
+                    ));
+        } catch (Exception e) {
+            throw new CommonException(ErrorCode.AUTH_SERVER_USER_INFO_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/springboot/mealkart/oauth2/GoogleResponse.java
+++ b/src/main/java/com/springboot/mealkart/oauth2/GoogleResponse.java
@@ -1,0 +1,31 @@
+package com.springboot.mealkart.oauth2;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class GoogleResponse implements OAuth2Response{
+
+    private  final Map<String, Object> attribute;
+
+    @Override
+    public String getSocialType() {
+        return "GOOGLE";
+    }
+
+    @Override
+    public String getUserId() {
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail(){
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName(){
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/com/springboot/mealkart/oauth2/KakaoResponse.java
+++ b/src/main/java/com/springboot/mealkart/oauth2/KakaoResponse.java
@@ -1,0 +1,32 @@
+package com.springboot.mealkart.oauth2;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class KakaoResponse implements OAuth2Response {
+
+    private  final Map<String, Object> attribute;
+
+    @Override
+    public String getSocialType() {
+        return "KAKAO";
+    }
+
+    @Override
+    public String getUserId() {
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail(){
+        return attribute.get("KakaoAccount.email").toString();
+    }
+
+    @Override
+    public String getName(){
+        return attribute.get("KakaoAccount.name").toString();
+    }
+
+}

--- a/src/main/java/com/springboot/mealkart/oauth2/OAuth2Attribute.java
+++ b/src/main/java/com/springboot/mealkart/oauth2/OAuth2Attribute.java
@@ -1,0 +1,43 @@
+package com.springboot.mealkart.oauth2;
+
+import com.springboot.mealkart.domain.User;
+import com.springboot.mealkart.enumerate.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuth2Attribute {
+    private Map<String, Object> attributes;
+    private String attributeKey;
+    private String email;
+    private String name;
+
+    @Builder
+    public OAuth2Attribute(Map<String, Object> attributes, String attributeKey, String email, String name) {
+        this.attributes = attributes;
+        this.attributeKey = attributeKey;
+        this.email = email;
+        this.name = name;
+    }
+
+    public static OAuth2Attribute of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuth2Attribute.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .attributes(attributes)
+                .attributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public User toEntity() {
+        return User
+                .builder()
+                .email(email)
+                .name(name)
+                .password("")
+                .userRole(UserRole.USER_CUSTOMER)
+                .build();
+    }
+}

--- a/src/main/java/com/springboot/mealkart/oauth2/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/springboot/mealkart/oauth2/OAuth2LoginFailureHandler.java
@@ -1,0 +1,24 @@
+package com.springboot.mealkart.oauth2;
+
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.naming.AuthenticationException;
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Value("${react.client}")
+    private String client;
+
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.sendRedirect(client);
+    }
+}

--- a/src/main/java/com/springboot/mealkart/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/springboot/mealkart/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,88 @@
+package com.springboot.mealkart.oauth2;
+
+import com.springboot.mealkart.domain.User;
+import com.springboot.mealkart.exception.CommonException;
+import com.springboot.mealkart.exception.ErrorCode;
+import com.springboot.mealkart.jwt.JwtUtil;
+import com.springboot.mealkart.repository.UserRepository;
+import com.springboot.mealkart.service.RedisService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+    private final RedisService redisService;
+    private final UserRepository userRepository;
+
+    @Value("${react.client}")
+    private String client;
+
+    @Transactional
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        // OAuth2User
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+
+        String userId = customUserDetails.getUserId();
+        String socialType = customUserDetails.getSocialType();
+        String name = customUserDetails.getName();
+
+        logger.debug("userId : " + userId);
+        logger.debug("providerType : " + socialType);
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+//        System.out.println("role : " + role);
+
+        String token = jwtUtil.createJwt(userId, socialType, role, 1000*60*3L);
+        response.addCookie(createCookie("Authorization", token));
+        String refreshToken = jwtUtil.createRefreshToken();
+        User user = userRepository.findByUserId(userId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
+        user.setRefreshToken(refreshToken);
+
+        log.info(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+        if (role.equals("ROLE_GUEST")){
+            String email = customUserDetails.getEmail();
+            redisService.save(userId, refreshToken);
+            response.sendRedirect(client + String.format("/register?email=%s&name=%s",email, name)); // 회원가입 폼으로
+        }else {
+            redisService.save(userId, refreshToken);
+            response.sendRedirect(client + "/");
+        }
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key,value);
+        cookie.setMaxAge(60*60*60);
+
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(false);
+        //cookie.setDomain("mealshop-shop.vercel.app");
+        cookie.setDomain("localhost:3000");
+        return cookie;
+    }
+}

--- a/src/main/java/com/springboot/mealkart/oauth2/OAuth2Response.java
+++ b/src/main/java/com/springboot/mealkart/oauth2/OAuth2Response.java
@@ -1,0 +1,16 @@
+package com.springboot.mealkart.oauth2;
+
+public interface OAuth2Response {
+
+    // 제공자 ex) naver, google
+    String getSocialType();
+
+    // 제공자에서 발급해주는 아이디(번호)
+    String getUserId();
+
+    // 이메일
+    String getEmail();
+
+    // 사용자 실명(설정한 이름)
+    String getName();
+}

--- a/src/main/java/com/springboot/mealkart/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/springboot/mealkart/oauth2/OAuth2UserInfo.java
@@ -1,0 +1,13 @@
+package com.springboot.mealkart.oauth2;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+    public OAuth2UserInfo (Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId();
+    public abstract String getName();
+}

--- a/src/main/java/com/springboot/mealkart/repository/UserRepository.java
+++ b/src/main/java/com/springboot/mealkart/repository/UserRepository.java
@@ -4,6 +4,11 @@ import com.springboot.mealkart.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, String> {
+
+    Optional<User> findByUserId(String userId);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/springboot/mealkart/service/RedisService.java
+++ b/src/main/java/com/springboot/mealkart/service/RedisService.java
@@ -1,0 +1,34 @@
+package com.springboot.mealkart.service;
+
+import com.springboot.mealkart.config.RedisConfig;
+import com.springboot.mealkart.exception.CommonException;
+import com.springboot.mealkart.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisConfig redisTemplate;
+
+    // 데이터 저장
+    public void save(String key, String value) {
+        redisTemplate.redisTemplate().opsForValue().set(key, value);
+    }
+
+    // 데이터 조회
+    public Object findByKey(String key) {
+        String val = redisTemplate.redisTemplate().opsForValue().get(key);
+        if(val != null) {
+            return val;
+        } else {
+            throw new CommonException(ErrorCode.ACCESS_DENIED_ERROR);
+        }
+    }
+
+    // 데이터 삭제
+    public void delete(String key) {
+        redisTemplate.redisTemplate().delete(key);
+    }
+}

--- a/src/main/java/com/springboot/mealkart/service/SellerService.java
+++ b/src/main/java/com/springboot/mealkart/service/SellerService.java
@@ -1,0 +1,80 @@
+package com.springboot.mealkart.service;
+
+import com.springboot.mealkart.domain.Seller;
+import com.springboot.mealkart.dto.SellerCreateDto;
+import com.springboot.mealkart.dto.SellerLoginDto;
+import com.springboot.mealkart.exception.CommonException;
+import com.springboot.mealkart.exception.ErrorCode;
+import com.springboot.mealkart.repository.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class SellerService {
+
+    private final SellerRepository sellerRepository;
+
+    /**
+     * Seller 생성 메소드
+     * @param dto
+     * @return
+     */
+    public Boolean createSeller(SellerCreateDto dto) {
+        sellerRepository.save(dto.toEntity());
+        return true;
+    }
+
+    /**
+     * 팡매자 로그인 메소드
+     * @param dto
+     * @return
+     */
+    public Boolean sellerLogin(SellerLoginDto dto) {
+        // 시큐리티 추가 후 수정 예정. 2025.04.06 added by hwanhee
+        return true;
+    }
+
+    /**
+     * 삭제(탈퇴) 메소드
+     * @param sellerUUID
+     * @return
+     */
+    public Boolean sellerDelete(String sellerUUID) {
+        Seller seller = sellerRepository
+                .findById(sellerUUID)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RESOURCE));
+        return seller.deactivate();
+    }
+
+    /**
+     * 비밀 번호 변경  메소드
+     * @param sellerUUID
+     * @param newPw
+     * @return
+     */
+    public Boolean sellerPwUpdate(String sellerUUID, String newPw) {
+        sellerRepository
+                .findById(sellerUUID)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RESOURCE))
+                .updatePasswordSeller(newPw);
+        return true;
+    }
+
+    /**
+     * 브랜드이름 변경 메소드
+     * @param sellerUUID
+     * @param newBrandName
+     * @return
+     */
+    public Boolean sellerBrandNameUpdate(String sellerUUID, String newBrandName) {
+        sellerRepository
+                .findById(sellerUUID)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RESOURCE))
+                .updateBrandNameSeller(newBrandName);
+        return true;
+    }
+
+}

--- a/src/main/java/com/springboot/mealkart/service/UserService.java
+++ b/src/main/java/com/springboot/mealkart/service/UserService.java
@@ -1,0 +1,35 @@
+package com.springboot.mealkart.service;
+
+import com.springboot.mealkart.dto.SellerLoginDto;
+import com.springboot.mealkart.dto.UserLoginDto;
+import com.springboot.mealkart.dto.UserRegDto;
+import com.springboot.mealkart.exception.CommonException;
+import com.springboot.mealkart.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 일반 로그인 회원가입 메소드
+     * @param dto
+     * @return
+     */
+    public Boolean registerUser(UserRegDto dto) {
+        if(userRepository.findByUserId(dto.userId()).isEmpty()) {
+           userRepository.save(dto.toEntity());
+           return true;
+        }else {
+            log.error("중복확인 제대로 처리되지 않음");
+            return false;
+        }
+    }
+
+
+}


### PR DESCRIPTION
## 🔎 Summary
# seller CUD 구현.

## 📑 Description
로그인 부분은 시큐리티 구현 시에 동시에 구현 예정.

비밀번호, 브랜드이름 수정 메소드 구현함.

Seller 구현 연속성을 가지려면 필자가 추후에 User도 같이 구현해야 할 것 같음.
## ✅ Check List
- 소스-타겟 브랜치 확인하기
- 코드 리뷰하기